### PR TITLE
Removed StringMetrics and added edit-distances repos

### DIFF
--- a/src/BaselineOfAIPharo/BaselineOfAIPharo.class.st
+++ b/src/BaselineOfAIPharo/BaselineOfAIPharo.class.st
@@ -19,43 +19,52 @@ BaselineOfAIPharo >> baseline: spec [
 BaselineOfAIPharo >> baselineGroups: spec [
 
 	spec
-		group: 'Core' 		with: #(
-				'AIDataInspector'
-				'AIHierarchicalClustering' 
-				'AIkNN' 
-				'AIKMeans' 
-				'AIMetrics' 
-				'AIViz' 
-				'APriori' 
-				'DecisionTreeModel' 
-				'Tfidf' 
-				'StringMetrics' 
-				'RandomPartitioner' 
-				'AIDatasets' 
-				'NaiveBayesClassifier' 
-				'AINLP' 
-				'AIGaussianMixtureModel');
-		group: 'default' 		with: #('Core')
+		group: 'Core'
+		with: #( 'AIDataInspector' 'AIHierarchicalClustering'
+			   'AIkNN' 'AIKMeans' 'AIMetrics' 'AIViz' 'APriori' 'DecisionTreeModel'
+			   'Tfidf' 'RandomPartitioner' 'AIDatasets' 'NaiveBayesClassifier'
+			   'AINLP' 'AIGaussianMixtureModel' 'AIEditDistances' );
+		group: 'default' with: #( 'Core' )
 ]
 
 { #category : #baselines }
 BaselineOfAIPharo >> baselineSpecs: spec [
 
-	spec 
-		baseline: 'AIDataInspector' 			with: [ spec repository: 'github://pharo-ai/data-inspector/src' ];
-		baseline: 'AIHierarchicalClustering' 	with: [ spec repository: 'github://pharo-ai/hierarchical-clustering/src' ];
-		baseline: 'AIkNN'						with: [ spec repository: 'github://pharo-ai/kNN/src' ];
-		baseline: 'AIKMeans'					with: [ spec repository: 'github://pharo-ai/k-means/src' ];
-		baseline: 'AIMetrics'					with: [ spec repository: 'github://pharo-ai/metrics/src' ];
-		baseline: 'AIViz'						with: [ spec repository: 'github://pharo-ai/viz/src' ];
-		baseline: 'APriori'						with: [ spec repository: 'github://pharo-ai/APriori/src' ];
-		baseline: 'AINLP'						with: [ spec repository: 'github://pharo-ai/nlp/src' ];
-		baseline: 'AINormalization'				with: [ spec repository: 'github://pharo-ai/normalization/src' ];
-		baseline: 'DecisionTreeModel'			with: [ spec repository: 'github://pharo-ai/decision-tree-model/src' ];
-		baseline: 'Tfidf'						with: [ spec repository: 'github://pharo-ai/tf-idf/src' ];
-		baseline: 'StringMetrics'				with: [ spec repository: 'github://pharo-ai/StringMetrics/src' ];
-		baseline: 'RandomPartitioner'			with: [ spec repository: 'github://pharo-ai/random-partitioner/src' ];
-		baseline: 'AIDatasets'					with: [ spec repository: 'github://pharo-ai/Datasets/' ];
-		baseline: 'AIGaussianMixtureModel'		with: [ spec repository: 'github://pharo-ai/gaussian-mixture-model/' ];
-		baseline: 'NaiveBayesClassifier'		with: [ spec repository: 'github://pharo-ai/naive-bayes-classifier/src' ].
+	spec
+		baseline: 'AIDataInspector'
+		with: [ spec repository: 'github://pharo-ai/data-inspector/src' ];
+		baseline: 'AIHierarchicalClustering'
+		with: [ 
+			spec repository: 'github://pharo-ai/hierarchical-clustering/src' ];
+		baseline: 'AIkNN'
+		with: [ spec repository: 'github://pharo-ai/kNN/src' ];
+		baseline: 'AIKMeans'
+		with: [ spec repository: 'github://pharo-ai/k-means/src' ];
+		baseline: 'AIMetrics'
+		with: [ spec repository: 'github://pharo-ai/metrics/src' ];
+		baseline: 'AIViz'
+		with: [ spec repository: 'github://pharo-ai/viz/src' ];
+		baseline: 'APriori'
+		with: [ spec repository: 'github://pharo-ai/APriori/src' ];
+		baseline: 'AINLP'
+		with: [ spec repository: 'github://pharo-ai/nlp/src' ];
+		baseline: 'AINormalization'
+		with: [ spec repository: 'github://pharo-ai/normalization/src' ];
+		baseline: 'DecisionTreeModel'
+		with: [ 
+			spec repository: 'github://pharo-ai/decision-tree-model/src' ];
+		baseline: 'Tfidf'
+		with: [ spec repository: 'github://pharo-ai/tf-idf/src' ];
+		baseline: 'RandomPartitioner'
+		with: [ spec repository: 'github://pharo-ai/random-partitioner/src' ];
+		baseline: 'AIDatasets'
+		with: [ spec repository: 'github://pharo-ai/Datasets/' ];
+		baseline: 'AIGaussianMixtureModel'
+		with: [ 
+			spec repository: 'github://pharo-ai/gaussian-mixture-model/' ];
+		baseline: 'NaiveBayesClassifier'
+		with: [ 
+			spec repository: 'github://pharo-ai/naive-bayes-classifier/src' ];
+		baseline: 'AIEditDistances'
+		with: [ spec repository: 'github://pharo-ai/edit-distances/src' ]
 ]

--- a/src/BaselineOfAIPharo/BaselineOfAIPharo.class.st
+++ b/src/BaselineOfAIPharo/BaselineOfAIPharo.class.st
@@ -31,40 +31,25 @@ BaselineOfAIPharo >> baselineGroups: spec [
 BaselineOfAIPharo >> baselineSpecs: spec [
 
 	spec
-		baseline: 'AIDataInspector'
-		with: [ spec repository: 'github://pharo-ai/data-inspector/src' ];
-		baseline: 'AIHierarchicalClustering'
-		with: [ 
+		baseline: 'AIDataInspector' with: [ spec repository: 'github://pharo-ai/data-inspector/src' ];
+		baseline: 'AIHierarchicalClustering' with: [ 
 			spec repository: 'github://pharo-ai/hierarchical-clustering/src' ];
-		baseline: 'AIkNN'
-		with: [ spec repository: 'github://pharo-ai/kNN/src' ];
-		baseline: 'AIKMeans'
-		with: [ spec repository: 'github://pharo-ai/k-means/src' ];
-		baseline: 'AIMetrics'
-		with: [ spec repository: 'github://pharo-ai/metrics/src' ];
-		baseline: 'AIViz'
-		with: [ spec repository: 'github://pharo-ai/viz/src' ];
-		baseline: 'APriori'
-		with: [ spec repository: 'github://pharo-ai/APriori/src' ];
-		baseline: 'AINLP'
-		with: [ spec repository: 'github://pharo-ai/nlp/src' ];
-		baseline: 'AINormalization'
-		with: [ spec repository: 'github://pharo-ai/normalization/src' ];
-		baseline: 'DecisionTreeModel'
-		with: [ 
+		baseline: 'AIkNN' with: [ spec repository: 'github://pharo-ai/kNN/src' ];
+		baseline: 'AIKMeans' with: [ spec repository: 'github://pharo-ai/k-means/src' ];
+		baseline: 'AIMetrics' with: [ spec repository: 'github://pharo-ai/metrics/src' ];
+		baseline: 'AIViz' with: [ spec repository: 'github://pharo-ai/viz/src' ];
+		baseline: 'APriori' with: [ spec repository: 'github://pharo-ai/APriori/src' ];
+		baseline: 'AINLP' with: [ spec repository: 'github://pharo-ai/nlp/src' ];
+		baseline: 'AINormalization' with: [ spec repository: 'github://pharo-ai/normalization/src' ];
+		baseline: 'DecisionTreeModel' with: [ 
 			spec repository: 'github://pharo-ai/decision-tree-model/src' ];
-		baseline: 'Tfidf'
-		with: [ spec repository: 'github://pharo-ai/tf-idf/src' ];
-		baseline: 'RandomPartitioner'
-		with: [ spec repository: 'github://pharo-ai/random-partitioner/src' ];
-		baseline: 'AIDatasets'
-		with: [ spec repository: 'github://pharo-ai/Datasets/' ];
-		baseline: 'AIGaussianMixtureModel'
-		with: [ 
+		baseline: 'Tfidf' with: [ spec repository: 'github://pharo-ai/tf-idf/src' ];
+		baseline: 'RandomPartitioner' with: [
+			spec repository: 'github://pharo-ai/random-partitioner/src' ];
+		baseline: 'AIDatasets' with: [ spec repository: 'github://pharo-ai/Datasets/' ];
+		baseline: 'AIGaussianMixtureModel' with: [ 
 			spec repository: 'github://pharo-ai/gaussian-mixture-model/' ];
-		baseline: 'NaiveBayesClassifier'
-		with: [ 
+		baseline: 'NaiveBayesClassifier' with: [ 
 			spec repository: 'github://pharo-ai/naive-bayes-classifier/src' ];
-		baseline: 'AIEditDistances'
-		with: [ spec repository: 'github://pharo-ai/edit-distances/src' ]
+		baseline: 'AIEditDistances' with: [ spec repository: 'github://pharo-ai/edit-distances/src' ]
 ]


### PR DESCRIPTION
The StringMetrics repo were removed from the meta package of AI. And edit-distances were added. This is because we are going to delete StringMetrics since edit-distances contains all the classes of StringMetrics.